### PR TITLE
Amend naming and syntax for existing landing zones

### DIFF
--- a/examples/avm/_platform/variables.tf
+++ b/examples/avm/_platform/variables.tf
@@ -23,8 +23,8 @@ variable "workload" {
     short_name = string
   })
   default = {
-    name       = "CICD Single Instance"
-    short_name = "cicd-si"
+    name       = "CICD Bicep"
+    short_name = "cicd-bicep"
   }
 }
 
@@ -59,8 +59,8 @@ variable "vnet_address_space" {
   default     = ["192.168.0.0/16"]
 }
 
-variable "compute_subnet_address_prefix" {
+variable "compute_subnet_address_prefixes" {
   description = "The address prefix for the compute subnet."
   type        = string
-  default     = "192.168.0.0/24"
+  default     = ["192.168.0.0/24"]
 }

--- a/examples/avm/_platform/virtual_networks.tf
+++ b/examples/avm/_platform/virtual_networks.tf
@@ -12,7 +12,7 @@ module "avm_cicd_vnet" {
   subnets = {
     compute = {
       name                   = "snet-compute-${local.resource_name_suffix}-01" # A key of "compute" becomes "snet-compute-dev-uks-01"
-      address_prefixes       = [var.compute_subnet_address_prefix]
+      address_prefixes       = var.compute_subnet_address_prefixes
       network_security_group = { id = module.avm_compute_nsg.resource_id } # Associate the "compute" NSG  with the "compute" subnet
       nat_gateway            = { id = module.avm_nat_gateway.resource_id } # Associate the NAT Gateway  with the "compute" subnet
     }

--- a/examples/avm/single-instance/main.tf
+++ b/examples/avm/single-instance/main.tf
@@ -11,7 +11,9 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy = true # Permanently delete Key Vault when the resource is destroyed. Used for testing purposes only.
+      # This setting allows Key Vaults to be destroyed even if they contain soft-deleted secrets
+      # Note: Use with caution in production environments
+      purge_soft_delete_on_destroy = true
     }
   }
 

--- a/examples/avm/single-instance/variables.tf
+++ b/examples/avm/single-instance/variables.tf
@@ -22,8 +22,8 @@ variable "workload" {
     short_name = string
   })
   default = {
-    name       = "CICD Single Instance"
-    short_name = "cicd-si"
+    name       = "CICD Bicep"
+    short_name = "cicd-bicep"
   }
 }
 
@@ -46,16 +46,17 @@ variable "location" {
 }
 
 # -- Existing resource references --
+# Hardcoded for simplicity in this example, but should be looked up programmatically in a production deployment
 variable "resource_group_name" {
   description = "The name of the resource group to use when looking up the existing resource group."
   type        = string
-  default     = "rg-qc-cicd-single-instance-dev-uks-01"
+  default     = "rg-qc-cicd-bicep-dev-uks-01"
 }
 
 variable "cicd_vnet_name" {
   description = "The name of the CI/CD virtual network to use when looking up the existing virtual network."
   type        = string
-  default     = "vnet-qc-cicd-single-instance-dev-uks-01"
+  default     = "vnet-qc-cicd-bicep-dev-uks-01"
 }
 
 variable "compute_subnet_name" {

--- a/examples/native/_platform/network_security_groups.tf
+++ b/examples/native/_platform/network_security_groups.tf
@@ -15,7 +15,7 @@ resource "azurerm_network_security_group" "compute" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = var.my_ip_address
+    source_address_prefix      = var.user_ip_address
     destination_address_prefix = azurerm_subnet.compute.address_prefixes[0]
     description                = "Allow SSH inbound traffic"
   }
@@ -28,7 +28,7 @@ resource "azurerm_network_security_group" "compute" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "3389"
-    source_address_prefix      = var.my_ip_address
+    source_address_prefix      = var.user_ip_address
     destination_address_prefix = azurerm_subnet.compute.address_prefixes[0]
     description                = "Allow RDP inbound traffic"
   }

--- a/examples/native/_platform/variables.tf
+++ b/examples/native/_platform/variables.tf
@@ -23,8 +23,8 @@ variable "workload" {
     short_name = string
   })
   default = {
-    name       = "CICD Single Instance"
-    short_name = "cicd-si"
+    name       = "CICD Terraform"
+    short_name = "cicd-tf"
   }
 }
 
@@ -47,7 +47,7 @@ variable "location" {
 }
 
 # -- Network Security Group variables --
-variable "my_ip_address" {
+variable "user_ip_address" {
   description = "Your public IP address in CIDR notation."
   type        = string
 }
@@ -59,8 +59,8 @@ variable "vnet_address_space" {
   default     = ["192.168.0.0/16"]
 }
 
-variable "compute_subnet_address_prefix" {
-  description = "The address prefix for the compute subnet."
-  type        = string
-  default     = "192.168.0.0/24"
+variable "compute_subnet_address_prefixes" {
+  description = "The address space for the compute subnet."
+  type        = array(string)
+  default     = ["192.168.0.0/24"]
 }

--- a/examples/native/_platform/virtual_networks.tf
+++ b/examples/native/_platform/virtual_networks.tf
@@ -11,5 +11,5 @@ resource "azurerm_subnet" "compute" {
   name                 = "snet-compute-${local.resource_name_suffix}-01"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.cicd.name
-  address_prefixes     = [var.compute_subnet_address_prefix]
+  address_prefixes     = var.compute_subnet_address_prefixes
 }

--- a/examples/native/single-instance/virtual_machines.linux.tf
+++ b/examples/native/single-instance/virtual_machines.linux.tf
@@ -48,7 +48,7 @@ resource "azurerm_network_interface" "linux" {
 
 # Create a Linux virtual machine
 resource "azurerm_linux_virtual_machine" "cicd" {
-  name                = "vm-${var.org.prefix}-cicd-linux-${var.environment}-${var.location.shortcode}-01" # "vm-qc-cicd-dev-uks-01"
+  name                = "vm-${var.org.prefix}-cicd-linux-${var.environment}-${var.location.shortcode}-01" # "vm-qc-cicd-linux-dev-uks-01"
   location            = data.azurerm_resource_group.rg.location
   resource_group_name = data.azurerm_resource_group.rg.name
 

--- a/examples/native/single-instance/virtual_machines.windows.tf
+++ b/examples/native/single-instance/virtual_machines.windows.tf
@@ -40,7 +40,7 @@ resource "azurerm_network_interface" "windows" {
 
 # Create a Windows virtual machine
 resource "azurerm_windows_virtual_machine" "cicd" {
-  name                = "vm-${local.resource_name_prefix}-windows-${local.resource_name_suffix}-01"           # "vm-qc-cicd-dev-uks-01"
+  name                = "vm-${local.resource_name_prefix}-windows-${local.resource_name_suffix}-01"           # "vm-qc-cicd-windows-dev-uks-01"
   computer_name       = upper(replace("VM${var.workload.short_name}${local.resource_name_suffix}1", "-", "")) # "VMCICDSIDEVUKS1"
   location            = data.azurerm_resource_group.rg.location
   resource_group_name = data.azurerm_resource_group.rg.name


### PR DESCRIPTION
This pull request updates naming conventions and variable structures across both Bicep and Terraform example environments to improve clarity and consistency. It also refines subnet and IP address variable usage to support multiple address prefixes and standardizes variable names for user IP addresses.

**Naming and Workload Convention Updates:**

* Changed default `workload` values from "CICD Single Instance" to "CICD Bicep" or "CICD Terraform" and updated associated `short_name` values in both Bicep and Terraform examples (`variables.tf`). [[1]](diffhunk://#diff-593cd214b0ecc4f1d89ef39f2e6012a6cb3129546f0ea3e5d3ab706dde470b2dL26-R27) [[2]](diffhunk://#diff-d3647e5929fd79105086c460d34dffd4f03142d6bf03293471b2fefec6a81a15L25-R26) [[3]](diffhunk://#diff-905be78c8bb979e9d164603066dc2d7b9e3c650cc6093602c40555ffd3f0b37cL26-R27)
* Updated resource group and virtual network default names to use "bicep" instead of "single-instance" for Bicep examples (`variables.tf`).
* Updated VM resource names to include the OS type (e.g., `cicd-linux`, `cicd-windows`) for clarity in both Linux and Windows examples. [[1]](diffhunk://#diff-30ed67030ce8d904e5bfaa52eaa1e77b25cd281157259eb1b3719d70b11b2e40L51-R51) [[2]](diffhunk://#diff-d54e0e7be1b7eb55b042b9f468c6f73bf7b115d92995185fd2c09d761a9269bdL43-R43)

**Subnet Address Prefix Handling:**

* Changed `compute_subnet_address_prefix` variables to `compute_subnet_address_prefixes`, now accepting arrays instead of single strings, for both Bicep and Terraform examples (`variables.tf`). [[1]](diffhunk://#diff-593cd214b0ecc4f1d89ef39f2e6012a6cb3129546f0ea3e5d3ab706dde470b2dL62-R65) [[2]](diffhunk://#diff-905be78c8bb979e9d164603066dc2d7b9e3c650cc6093602c40555ffd3f0b37cL62-R65)
* Updated subnet resource definitions to use the new `compute_subnet_address_prefixes` variable directly, supporting multiple prefixes (`virtual_networks.tf`). [[1]](diffhunk://#diff-7e49272368126656d8fb6820de2dc14bcde16ec65e56e729f05ad142b985eb96L15-R15) [[2]](diffhunk://#diff-8fc775c8c83a2d21a784964b09de91b87236d047186263769fbfa266d2df031aL14-R14)

**Network Security Group and IP Variable Standardization:**

* Renamed `my_ip_address` variable to `user_ip_address` for clarity in native Terraform examples (`variables.tf`).
* Updated network security group rules to reference `user_ip_address` instead of `my_ip_address` for SSH and RDP access (`network_security_groups.tf`). [[1]](diffhunk://#diff-9fc9dde3d0a4325624bd795074c5243b55d22ce736d67fe23f2f7dd395d84ddcL18-R18) [[2]](diffhunk://#diff-9fc9dde3d0a4325624bd795074c5243b55d22ce736d67fe23f2f7dd395d84ddcL31-R31)

**Documentation and Safety Improvements:**

* Added clarifying comments regarding the use of `purge_soft_delete_on_destroy` in Key Vault provider configuration, emphasizing caution in production (`main.tf`).