### PR TITLE
Add native Terraform VMSS example

### DIFF
--- a/examples/native/vmss/README.md
+++ b/examples/native/vmss/README.md
@@ -1,0 +1,119 @@
+## CICD Virtual Machine Scale Set Example with Terraform
+
+This folder contains a small Terraform example that provisions a virtual machine scale set environment intended for CI/CD self-hosted-agent for demonstrating and testing purposes.
+
+### Quick summary
+- Deploys a Key Vault for secrets with a Linux and/or Windows virtual machine.
+- The example uses native Terraform (i.e., no modules) and creates resources suitable for short-lived test environments or demos.
+- The example platform resources (vNet, subnet, NSG, NAT Gateway) are expected to be already deployed (e.g., see the [_platform](../_platform) example).
+
+### What is deployed (high level)
+- Key Vault for secrets
+- SSH public key and secrets stored in Key Vault
+- Virtual Machine Scale Set(s) — defined in `virtual_machine_scale_sets.linux.tf` and `virtual_machine_scale_sets.windows.tf`
+- Public IPs for administrative connectivity to the VMSS
+
+### Resources consumed (billing considerations)
+- **Virtual Machines** (default size `Standard_B2s`): Billed per hour while running.
+- **Managed OS disks**: Billed per GB/month.
+- **Public IP addresses** (per IP) if the VMSS require direct public inbound access.
+- **Key Vault**: Small monthly cost; API operation charges may apply.
+
+### Notes
+- This example is intended for demos and testing.
+- Review VM sizes, images, identity, and key management before using in production.
+- Costs vary by region and usage; consult the Azure Pricing Calculator for exact numbers.
+
+## Deploy only Linux or only Windows
+The Linux and Windows VM resources live in separate files. To deploy only one OS family, rename the file you don't want to deploy so it doesn't end with `.tf` (e.g. `virtual_machine_scale_sets.windows.tf.disabled`).
+
+## Basic Terraform workflow
+
+```bash
+terraform init
+terraform plan -out plan.tfplan
+terraform apply plan.tfplan
+```
+
+## Developer notes
+- Example variables are provided in `variables.tf` and can be overridden with `-var` or `*.tfvars` files. `vm_size` defaults to `Standard_B2s`.
+
+## Configuring a VMSS Agent Pool in Azure DevOps
+### Organization-level setup
+1. In your Azure DevOps organization, navigate to **Organization Settings** > **Agent Pools** (under **Pipelines**).
+2. Click **Add Pool** and select **Azure virtual machine scale set**.
+3. Select a Service Connection or Subscription to connect the VMSS to.
+4. Select the subscription where your VMSS is deployed.
+5. Select the Virtual machine scale set from the dropdown.
+6. Provide a display name for the agent pool. This will be the name you use to reference this pool in your pipelines.
+7. Configure the pool options accordingly. This can be changed later if needed.
+8. Click **Create** to finalize the setup.
+
+## Project-level setup
+9. Navigate to your project in Azure DevOps, then go to **Project Settings** > **Pipelines** > **Agent Pools**.
+10. Click **Add Pool** and select **Existing**.
+10. Select the agent pool you just created at the organization level and click **Create**.
+11. You can now use this agent pool in your pipeline YAML files by specifying the pool name.
+
+Azure DevOps will then connect to the VMSS and start provisioning agents based on the VMSS configuration. You can monitor the status of the agents in the Agent Pools section. There may be a short delay before the agents appear as available, but there is no need to manually install the Azure Pipelines agent on the VMSS instances nor manually spin up or down instances; this is handled automatically by Azure DevOps.
+
+## Image Mangement
+The example uses the latest available platform images from the Azure Marketplace. For production use, consider using a custom image or image versioning strategy to ensure consistency and control over updates.
+
+Best practices for managing VM images in a production environment include:
+- Using HashiCorp Packer or Azure Image Builder to automatically create and maintain custom images with pre-installed software and configurations.
+- Manually updating golden images to include the latest security patches and software updates.
+- Implementing a versioning strategy to track and deploy specific image versions for consistency across deployments and easy rollback if needed.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.46.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
+| [azurerm_key_vault_access_policy.current_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.admin_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_windows_virtual_machine_scale_set.cicd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine_scale_set) | resource |
+| [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_subnet.compute](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | The admin username for the Virtual Machine. | `string` | `"azureadmin"` | no |
+| <a name="input_cicd_vnet_name"></a> [cicd\_vnet\_name](#input\_cicd\_vnet\_name) | The name of the CI/CD virtual network to use when looking up the existing virtual network. | `string` | `"vnet-qc-cicd-terraform-dev-uks-01"` | no |
+| <a name="input_compute_subnet_name"></a> [compute\_subnet\_name](#input\_compute\_subnet\_name) | The name of the compute subnet to use when looking up the existing subnet. | `string` | `"snet-compute-dev-uks-01"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment for the deployment (e.g., dev, test, prod). | `string` | `"dev"` | no |
+| <a name="input_key_vault_ip_rules"></a> [key\_vault\_ip\_rules](#input\_key\_vault\_ip\_rules) | List of IP addresses or CIDR ranges that are allowed to access the Key Vault. | `list(string)` | `[]` | no |
+| <a name="input_location"></a> [location](#input\_location) | The Azure region to deploy resources into. | <pre>object({<br/>    name      = string<br/>    shortcode = string<br/>  })</pre> | <pre>{<br/>  "name": "UK South",<br/>  "shortcode": "uks"<br/>}</pre> | no |
+| <a name="input_org"></a> [org](#input\_org) | Configuration details for the organisation, to be used for naming and tags for all resources created. | <pre>object({<br/>    name   = string<br/>    prefix = string<br/>  })</pre> | <pre>{<br/>  "name": "Quadrivium Cloud",<br/>  "prefix": "qc"<br/>}</pre> | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to use when looking up the existing resource group. | `string` | `"rg-qc-cicd-terraform-dev-uks-01"` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Subscription ID which should be used to deploy resources in to. | `string` | n/a | yes |
+| <a name="input_user_ip_address"></a> [user\_ip\_address](#input\_user\_ip\_address) | Your public IP address in CIDR notation. | `string` | n/a | yes |
+| <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | The size of the Virtual Machine. | `string` | `"Standard_B2s"` | no |
+| <a name="input_workload"></a> [workload](#input\_workload) | Configuration details for the workload being deployed. | <pre>object({<br/>    name       = string<br/>    short_name = string<br/>  })</pre> | <pre>{<br/>  "name": "CICD Terraform",<br/>  "short_name": "cicd-tf"<br/>}</pre> | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/examples/native/vmss/README.md
+++ b/examples/native/vmss/README.md
@@ -78,6 +78,7 @@ Best practices for managing VM images in a production environment include:
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.46.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
 
 ## Modules
 
@@ -90,8 +91,12 @@ No modules.
 | [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_access_policy.current_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.admin_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.admin_ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_linux_virtual_machine_scale_set.cicd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set) | resource |
+| [azurerm_ssh_public_key.admin_ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/ssh_public_key) | resource |
 | [azurerm_windows_virtual_machine_scale_set.cicd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine_scale_set) | resource |
 | [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [tls_private_key.admin_ssh_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subnet.compute](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |

--- a/examples/native/vmss/data.tf
+++ b/examples/native/vmss/data.tf
@@ -1,0 +1,14 @@
+# Get information about the current Azure client
+data "azurerm_client_config" "current" {}
+
+# Get the CI/CD resource group
+data "azurerm_resource_group" "rg" {
+  name = var.resource_group_name
+}
+
+# Get the CI/CD compute subnet
+data "azurerm_subnet" "compute" {
+  name                 = var.compute_subnet_name
+  virtual_network_name = var.cicd_vnet_name
+  resource_group_name  = data.azurerm_resource_group.rg.name
+}

--- a/examples/native/vmss/key_vaults.tf
+++ b/examples/native/vmss/key_vaults.tf
@@ -1,0 +1,37 @@
+# Create a Key Vault to store the admin credentials
+resource "azurerm_key_vault" "kv" {
+  # Key Vault name must be globally unique and not greater than 24 characters
+  name                = replace("kv${local.resource_short_name_base}01", "-", "") # "kvqccicdsidevuks01"
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  # Key Vault settings
+  sku_name                   = "standard"
+  purge_protection_enabled   = false
+  soft_delete_retention_days = 7
+
+  # Network access settings
+  network_acls {
+    default_action = "Deny"
+    bypass         = "AzureServices"
+    ip_rules       = concat([var.user_ip_address], var.key_vault_ip_rules)
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "current_user" {
+  key_vault_id = azurerm_key_vault.kv.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id # The currently authenticated user
+
+  secret_permissions = [
+    "Get",
+    "List",
+    "Set",
+    "Delete",
+    "Recover",
+    "Backup",
+    "Restore",
+    "Purge"
+  ]
+}

--- a/examples/native/vmss/main.tf
+++ b/examples/native/vmss/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {
+    key_vault {
+      # This setting allows Key Vaults to be destroyed even if they contain soft-deleted secrets
+      # Note: Use with caution in production environments
+      purge_soft_delete_on_destroy = true
+    }
+  }
+
+  subscription_id = var.subscription_id
+}
+
+# Define local values to be used for naming resources
+locals {
+  # Format the workload name to be used for naming resources
+  name_slug                = lower(replace(var.workload.name, " ", "-"))
+  resource_name_prefix     = lower("${var.org.prefix}-${local.name_slug}")                                       # "qc-cicd-single-instance"
+  resource_name_suffix     = lower("${var.environment}-${var.location.shortcode}")                               # "dev-uks"
+  resource_name_base       = lower("${local.resource_name_prefix}-${local.resource_name_suffix}")                # "qc-cicd-single-instance-dev-uks"
+  resource_short_name_base = lower("${var.org.prefix}-${var.workload.short_name}-${local.resource_name_suffix}") # "qc-cicd-si-dev-uks"
+}

--- a/examples/native/vmss/variables.tf
+++ b/examples/native/vmss/variables.tf
@@ -1,0 +1,92 @@
+# -- Workload specific variables --
+variable "subscription_id" {
+  description = "The Subscription ID which should be used to deploy resources in to."
+  type        = string
+}
+
+variable "org" {
+  description = "Configuration details for the organisation, to be used for naming and tags for all resources created."
+  type = object({
+    name   = string
+    prefix = string
+  })
+  default = {
+    name   = "Quadrivium Cloud"
+    prefix = "qc"
+  }
+}
+
+variable "workload" {
+  description = "Configuration details for the workload being deployed."
+  type = object({
+    name       = string
+    short_name = string
+  })
+  default = {
+    name       = "CICD Terraform"
+    short_name = "cicd-tf"
+  }
+}
+
+variable "environment" {
+  description = "The environment for the deployment (e.g., dev, test, prod)."
+  type        = string
+  default     = "dev"
+}
+
+variable "location" {
+  description = "The Azure region to deploy resources into."
+  type = object({
+    name      = string
+    shortcode = string
+  })
+  default = {
+    name      = "UK South"
+    shortcode = "uks"
+  }
+}
+
+# -- Existing resource references --
+# Hardcoded for simplicity in this example, but should be looked up programmatically in a production deployment
+variable "resource_group_name" {
+  description = "The name of the resource group to use when looking up the existing resource group."
+  type        = string
+  default     = "rg-qc-cicd-terraform-dev-uks-01"
+}
+
+variable "cicd_vnet_name" {
+  description = "The name of the CI/CD virtual network to use when looking up the existing virtual network."
+  type        = string
+  default     = "vnet-qc-cicd-terraform-dev-uks-01"
+}
+
+variable "compute_subnet_name" {
+  description = "The name of the compute subnet to use when looking up the existing subnet."
+  type        = string
+  default     = "snet-compute-dev-uks-01"
+}
+
+# -- Key Vault variables --
+variable "user_ip_address" {
+  description = "Your public IP address in CIDR notation."
+  type        = string
+}
+
+variable "key_vault_ip_rules" {
+  description = "List of IP addresses or CIDR ranges that are allowed to access the Key Vault."
+  type        = list(string)
+  default     = []
+}
+
+# -- Virtual Machine variables --
+variable "admin_username" {
+  description = "The admin username for the Virtual Machine."
+  type        = string
+  default     = "azureadmin"
+}
+
+variable "vm_size" {
+  description = "The size of the Virtual Machine."
+  type        = string
+  default     = "Standard_B2s"
+}

--- a/examples/native/vmss/virtual_machine_scale_sets.linux.tf
+++ b/examples/native/vmss/virtual_machine_scale_sets.linux.tf
@@ -1,0 +1,71 @@
+# Create an SSH public key for the admin user
+resource "tls_private_key" "admin_ssh_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+# Upload the SSH public key to Azure
+resource "azurerm_ssh_public_key" "admin_ssh_key" {
+  name                = "sshkey-${local.resource_name_prefix}-linux-${local.resource_name_suffix}-01" # "sshkey-qc-cicd-linux-dev-uks-01"
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+
+  public_key = tls_private_key.admin_ssh_key.public_key_openssh
+}
+
+# Save the SSH private key in a Key Vault secret
+resource "azurerm_key_vault_secret" "admin_ssh_key" {
+  name         = "${var.workload.short_name}-vmss-admin-ssh-key" # "cicd-tf-vmss-admin-ssh-key"
+  value        = tls_private_key.admin_ssh_key.private_key_pem
+  key_vault_id = azurerm_key_vault.kv.id
+
+  # Ensure Key Vault is created before adding the secret and removes the secret first if the Key Vault is deleted
+  depends_on = [azurerm_key_vault_access_policy.current_user]
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "cicd" {
+  name                = "vmss-${var.org.prefix}-cicd-linux-${var.environment}-${var.location.shortcode}-01" # "vmss-qc-cicd-linux-dev-uks-01"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.rg.location
+
+  sku                  = "Standard_B2s"
+  instances            = 1
+  computer_name_prefix = "vm-"
+
+  admin_username = var.admin_username
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = tls_private_key.admin_ssh_key.public_key_openssh
+  }
+
+  # Required for Azure DevOps self-hosted agents
+  overprovision          = false
+  single_placement_group = true
+
+  network_interface {
+    name    = "nic-${local.resource_short_name_base}-01" # "nic-qc-cicd-tf-dev-uks-01"
+    primary = true
+
+    ip_configuration {
+      name      = "ipconfig"
+      subnet_id = data.azurerm_subnet.compute.id
+      primary   = true
+    }
+  }
+
+  os_disk {
+    storage_account_type = "StandardSSD_LRS"
+    caching              = "ReadWrite"
+  }
+
+  # To see available images, run:
+  # az vm image list-skus --location <region> --publisher MicrosoftWindowsServer --offer WindowsServer --output table
+  # Use an Azure Marketplace image or a custom image
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+}

--- a/examples/native/vmss/virtual_machine_scale_sets.windows.tf
+++ b/examples/native/vmss/virtual_machine_scale_sets.windows.tf
@@ -1,0 +1,59 @@
+# Create a random password for the admin user
+resource "random_password" "admin_password" {
+  length           = 16
+  special          = true
+  override_special = "!@#$%&*()-_=+[]{}<>:?"
+}
+
+# Save the admin password in a Key Vault secret
+resource "azurerm_key_vault_secret" "admin_password" {
+  name         = "cicd-vms-admin-password"
+  value        = random_password.admin_password.result
+  key_vault_id = azurerm_key_vault.kv.id
+
+  # Ensure Key Vault is created before adding the secret
+  depends_on = [azurerm_key_vault_access_policy.current_user]
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "cicd" {
+  name                = "vmss-${var.org.prefix}-cicd-windows-${var.environment}-${var.location.shortcode}-01" # "vmss-qc-cicd-windows-dev-uks-01"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.rg.location
+
+  sku                  = "Standard_B2s"
+  instances            = 1
+  computer_name_prefix = "vm-"
+
+  admin_password = random_password.admin_password.result
+  admin_username = "azureadmin"
+
+  # Required for Azure DevOps self-hosted agents
+  overprovision          = false
+  single_placement_group = true
+
+  network_interface {
+    name    = "nic-${local.resource_short_name_base}-01" # "nic-qc-cicd-si-dev-uks-01"
+    primary = true
+
+    ip_configuration {
+      name      = "ipconfig"
+      subnet_id = data.azurerm_subnet.compute.id
+      primary   = true
+    }
+  }
+
+  os_disk {
+    storage_account_type = "StandardSSD_LRS"
+    caching              = "ReadWrite"
+  }
+
+  # To see available images, run:
+  # az vm image list-skus --location <region> --publisher MicrosoftWindowsServer --offer WindowsServer --output table
+  # Use an Azure Marketplace image or a custom image
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2025-datacenter-core-smalldisk-g2"
+    version   = "latest"
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Terraform example for provisioning a CI/CD Virtual Machine Scale Set (VMSS) environment in Azure, designed for demo and testing purposes. The implementation is fully native (no modules) and covers both Linux and Windows VMSS scenarios, with secure credential handling via Azure Key Vault. The example includes clear documentation and variables for customization, and expects certain platform resources to already exist.

The most important changes are grouped as follows:

**Documentation and Usage Guidance**
- Added comprehensive `README.md` with step-by-step deployment instructions, Azure DevOps agent pool integration, image management best practices, and an auto-generated Terraform documentation section describing resources, inputs, and outputs.

**Terraform Configuration and Resource Management**
- Introduced a new set of Terraform files (`main.tf`, `variables.tf`, `data.tf`) for provider configuration, local naming conventions, input variables, and data sources to fetch existing Azure resources. [[1]](diffhunk://#diff-470eece42fdd7ecd87596507e050df729342e13399c5dafa0d6c72a9034fe638R1-R31) [[2]](diffhunk://#diff-6642e9ef8c6927152410c2af08e0bbe8ffeef4b8abe06bd6417e040aa5df3f4dR1-R92) [[3]](diffhunk://#diff-bb5fdcae2cc0dcb632ce9e7b535c4a7c4e8727bb3a435853062e7b9a0c6b389fR1-R14)
- Added resources for secure credential management, including creation of an Azure Key Vault, access policies for the current user, and network ACLs for restricted access.

**Linux and Windows VMSS Deployment**
- Added resources to deploy a Linux VMSS, including automated SSH key generation, storage of the private key in Key Vault, and configuration of the VMSS with the latest Ubuntu image.
- Added resources to deploy a Windows VMSS, including secure random password generation, storage in Key Vault, and configuration of the VMSS with the latest Windows Server image.